### PR TITLE
Update package urls and checksums

### DIFF
--- a/recipes/_mac_os_x.rb
+++ b/recipes/_mac_os_x.rb
@@ -17,13 +17,16 @@
 # limitations under the License.
 #
 
-remote_file "#{Chef::Config[:file_cache_path]}/HipChat-2.5.6-87.zip" do
-  source 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.5.6-87.zip'
-  checksum '8d764118f93efed5e6fc61dffa00da26d946a84a9e35ca2e07babdaa075760db'
+HC_OSX_VERSION = '4.29.0-732'
+HC_OSX_CHECKSUM = 'b033c8e69686810e7f83e0895a90ed22d745af5956b5bb1cf4cda37756dc910b'
+
+remote_file "#{Chef::Config[:file_cache_path]}/HipChat-#{HC_OSX_VERSION}.zip" do
+  source "https://s3.amazonaws.com/downloads.hipchat.com/osx/HipChat-#{HC_OSX_VERSION}.zip"
+  checksum "#{HC_OSX_CHECKSUM}"
   notifies :run, 'execute[unzip-hipchat]'
 end
 
 execute 'unzip-hipchat' do
-  command "unzip #{Chef::Config[:file_cache_path]}/HipChat-2.5.6-87.zip -d /Applications"
+  command "unzip #{Chef::Config[:file_cache_path]}/HipChat-#{HC_OSX_VERSION}.zip -d /Applications"
   action :nothing
 end

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -18,6 +18,7 @@
 #
 
 package 'HipChat' do
-  source 'http://downloads.hipchat.com/windows/HipChat-2.2.1107-win32.msi'
+  source 'https://atlassian.jfrog.io/atlassian/libqt-hipchat/HipChat-4.30.1.1663-win32.msi'
+  checksum '7ad43cd85dcbb68a9fde1a1fd1216d2318ad1bfef580ebf631894edbba89407e'
   action :install
 end


### PR DESCRIPTION
I updated the package urls and checksums for OSX and Windows. I also added the appropriate checksum for the Windows archive. I was not able to verify the Windows instance but did verify the OSX installation in KitchenCI. In fact, let me update that.